### PR TITLE
Removing deprecated `prometheus` function

### DIFF
--- a/default/pipelines/logs_to_metrics/conf.yml
+++ b/default/pipelines/logs_to_metrics/conf.yml
@@ -89,12 +89,3 @@ functions:
         - category_id
       cumulative: false
     description: Aggregate Web Access Logs
-  - id: prometheus
-    filter: sourcetype=='access_combined'
-    disabled: null
-    conf:
-      batchWriteInterval: 5000
-      passthrough: true
-      update: true
-      fields: 
-        - "*"


### PR DESCRIPTION
`logs_to_metrics` utilized deprecated `prometheus` function -- removed