### PR TITLE
removing REDIS and REST functions

### DIFF
--- a/default/pipelines/enrich/conf.yml
+++ b/default/pipelines/enrich/conf.yml
@@ -75,48 +75,11 @@ functions:
     conf:
       ignoreFields:
         - status
-  - id: comment
-    filter: "true"
-    disabled: null
-    conf:
-      comment: Lookup JSESSIONID against Redis
-  - id: redis
-    filter: "true"
-    disabled: null
-    conf:
-      commands:
-        - command: get
-          outField: userName
-          keyExpr: "`session_${JSESSIONID}`"
-      maxBlockSecs: 60
-      url: redis://redis:6379
-  - id: comment
-    filter: "true"
-    disabled: null
-    conf:
-      comment: Lookup userName against REST API
-  - id: demo_restLookup
-    filter: "true"
-    disabled: false
-    conf:
-      urlExpression: "`http://apiserver:4000/users/${userName}`"
-      eventField: customer
-      maxConcurrentRequests: 1
-      retryOnError: true
   - id: eval
     filter: "true"
     disabled: null
     conf:
       remove:
         - httpBasicUser
-  - id: flatten
-    filter: customer
-    disabled: null
-    conf:
-      fields:
-        - customer
-      prefix: ""
-      depth: 5
-      delimiter: _
 output: default
 groups: {}


### PR DESCRIPTION
REDIS and REST functions no longer work as their backends have been removed in the jump to `demo-standard`